### PR TITLE
使用HtmlUnitPageLoader加载的页面获取不到当前页面url

### DIFF
--- a/src/main/java/com/xuxueli/crawler/loader/strategy/HtmlUnitPageLoader.java
+++ b/src/main/java/com/xuxueli/crawler/loader/strategy/HtmlUnitPageLoader.java
@@ -91,6 +91,7 @@ public class HtmlUnitPageLoader extends PageLoader {
             String pageAsXml = page.asXml();
             if (pageAsXml != null) {
                 Document html = Jsoup.parse(pageAsXml);
+                html.setBaseUri(pageRequest.getUrl());
                 return html;
             }
         } catch (IOException e) {


### PR DESCRIPTION

```java
Document html = Jsoup.parse(pageAsXml);
```
返回的html没有baseurl,后期使用获取不到，如图


手工set了一下
```java
Document html = Jsoup.parse(pageAsXml);
html.setBaseUri(pageRequest.getUrl());
```

![](http://pic.wmgblog.pw/20190309114311.png)
